### PR TITLE
fix: Ensure `tracePropagationTargets` correctly serializes RegExp

### DIFF
--- a/src/web-accessible-script/serializeOptions.ts
+++ b/src/web-accessible-script/serializeOptions.ts
@@ -36,6 +36,11 @@ export function serializeOptions(client: Client | undefined, options: Options | 
 		opts['[installedIntegrations]'] = allIntegrations;
 	}
 
+	// Ensure we properly serialize RegExp values
+	if (Array.isArray(options.tracePropagationTargets)) {
+		opts.tracePropagationTargets = options.tracePropagationTargets.map((target) => `${target}`);
+	}
+
 	return opts;
 }
 


### PR DESCRIPTION
Instead of currently:

```js
const tracePropagationTargets = ['/api', /\/api/];
// JSON.stringify(tracePropagationTargets) --> ['/api', {}]
```

We now properly serialize RegExp expressions, so it would output:

```js
['/api', '/\\/api/']
```