### PR TITLE
feat: Bump internal Sentry SDK to v10.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
 		"webextension-polyfill": "^0.10.0"
 	},
 	"dependencies": {
-		"@sentry/browser": "^9.10.1",
-		"@sentry/core": "^9.10.1",
+		"@sentry/browser": "^10.2.0",
+		"@sentry/core": "^10.2.0",
 		"@solidjs/router": "^0.14.3",
 		"@spotlightjs/overlay": "2.4.0-next.4",
 		"highlight.js": "^11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,61 +852,61 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/browser-utils@npm:9.10.1":
-  version: 9.10.1
-  resolution: "@sentry-internal/browser-utils@npm:9.10.1"
+"@sentry-internal/browser-utils@npm:10.2.0":
+  version: 10.2.0
+  resolution: "@sentry-internal/browser-utils@npm:10.2.0"
   dependencies:
-    "@sentry/core": "npm:9.10.1"
-  checksum: 10c0/aa56c8514f2b56e7e5a53f481045bd9dcb6ecc883092319d95618294400884224d7444d9fa80f78225066c2d4009dfbf125b508703a6f1154e6fb6428c5a4228
+    "@sentry/core": "npm:10.2.0"
+  checksum: 10c0/d3b95f4b774a2dfb862abd8b0f346c41f96547f6f4ecea63f6ed7d1dfd133115ba59e8d8d25af1fe4f971759ef73c602b0e4529639b73161febe53e7a8f41163
   languageName: node
   linkType: hard
 
-"@sentry-internal/feedback@npm:9.10.1":
-  version: 9.10.1
-  resolution: "@sentry-internal/feedback@npm:9.10.1"
+"@sentry-internal/feedback@npm:10.2.0":
+  version: 10.2.0
+  resolution: "@sentry-internal/feedback@npm:10.2.0"
   dependencies:
-    "@sentry/core": "npm:9.10.1"
-  checksum: 10c0/eff093e1b6223c353290ddcde0efab6ea614375d96bad8098e70efbad31739080d337d0807ed6fd5ab2103ec77e6b55b631f8c7daa25b7f2beb72c7aaa7fb0d6
+    "@sentry/core": "npm:10.2.0"
+  checksum: 10c0/94b536350cdbfc983668eda7aa0ee239bd27816f5a020ab10732132a5327382a0134accb714dd4bfd4644e252904c7ceb9226922c043dbf9965068b6fffc0af6
   languageName: node
   linkType: hard
 
-"@sentry-internal/replay-canvas@npm:9.10.1":
-  version: 9.10.1
-  resolution: "@sentry-internal/replay-canvas@npm:9.10.1"
+"@sentry-internal/replay-canvas@npm:10.2.0":
+  version: 10.2.0
+  resolution: "@sentry-internal/replay-canvas@npm:10.2.0"
   dependencies:
-    "@sentry-internal/replay": "npm:9.10.1"
-    "@sentry/core": "npm:9.10.1"
-  checksum: 10c0/4352046a67cec765f6c06709e4ecafb2120fda612981e2d3a22a9e6e4eb3d456d05fb4d4f9a6b92d2701b7bb186452649377274f0fe5f2c268d700f5a1ad95c6
+    "@sentry-internal/replay": "npm:10.2.0"
+    "@sentry/core": "npm:10.2.0"
+  checksum: 10c0/073af8af7021ce039ad67623d559bbdfd348dd1438a3e136764537af090fccd74a2f27847af82c495a36f416182608cbb2a01a90169c89122ba39fbb87544468
   languageName: node
   linkType: hard
 
-"@sentry-internal/replay@npm:9.10.1":
-  version: 9.10.1
-  resolution: "@sentry-internal/replay@npm:9.10.1"
+"@sentry-internal/replay@npm:10.2.0":
+  version: 10.2.0
+  resolution: "@sentry-internal/replay@npm:10.2.0"
   dependencies:
-    "@sentry-internal/browser-utils": "npm:9.10.1"
-    "@sentry/core": "npm:9.10.1"
-  checksum: 10c0/0926746aa1e779a2fd05725f66607b4e3b55e5a081969f38777d172e62f12873c4563298ab4afe83362f7c23b0a6d3cc6ca7a541e76cfc67a5454980620b8abf
+    "@sentry-internal/browser-utils": "npm:10.2.0"
+    "@sentry/core": "npm:10.2.0"
+  checksum: 10c0/b906af1a73607cf1a568d7da53c1bf58a1b74a4522e44a60870275bcbb727aa7a09f2e4d368af1cb458f0e7586a82194b8dcbeb7d16d73b8abc927f3e5972d61
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:^9.10.1":
-  version: 9.10.1
-  resolution: "@sentry/browser@npm:9.10.1"
+"@sentry/browser@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "@sentry/browser@npm:10.2.0"
   dependencies:
-    "@sentry-internal/browser-utils": "npm:9.10.1"
-    "@sentry-internal/feedback": "npm:9.10.1"
-    "@sentry-internal/replay": "npm:9.10.1"
-    "@sentry-internal/replay-canvas": "npm:9.10.1"
-    "@sentry/core": "npm:9.10.1"
-  checksum: 10c0/b2e9e39be9a0168ab3ba9806e9ef87aebe6bc0f33c2f9545cad371dc6dbb0a56dc6b4b5c334e7e4305c52ea9d4a837d6e4af8b34014cb9e7c470c917da34adf5
+    "@sentry-internal/browser-utils": "npm:10.2.0"
+    "@sentry-internal/feedback": "npm:10.2.0"
+    "@sentry-internal/replay": "npm:10.2.0"
+    "@sentry-internal/replay-canvas": "npm:10.2.0"
+    "@sentry/core": "npm:10.2.0"
+  checksum: 10c0/57a5c8621448b6de705ff5cd47168278f055686290299e52a76c0a643317d9fbe5c5638f3161fb2758ce00d8c28b61f23bd8fd8a34cee1392299ea84c428e934
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:9.10.1, @sentry/core@npm:^9.10.1":
-  version: 9.10.1
-  resolution: "@sentry/core@npm:9.10.1"
-  checksum: 10c0/c7c6279dd536edd8c0eb695c6d63f00f5b9f5e6b460129c7e2f9722db92722e6b195d9da163611343a4e9d40f7c24bf4a88dd5bd3bb951d4f8acde70ce772123
+"@sentry/core@npm:10.2.0, @sentry/core@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "@sentry/core@npm:10.2.0"
+  checksum: 10c0/2c04cb1fc77ad89fdac7573ee089c1c8111c094c3c77e84ce019e28ac02f6cdefd30d9860717089c80b6f2301c01a1829f10116e5222a803eaac5520a7e1363b
   languageName: node
   linkType: hard
 
@@ -3686,8 +3686,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "sentry-sdk-browser-extension@workspace:."
   dependencies:
-    "@sentry/browser": "npm:^9.10.1"
-    "@sentry/core": "npm:^9.10.1"
+    "@sentry/browser": "npm:^10.2.0"
+    "@sentry/core": "npm:^10.2.0"
     "@solidjs/router": "npm:^0.14.3"
     "@spotlightjs/overlay": "npm:2.4.0-next.4"
     "@types/webextension-polyfill": "npm:^0.10.0"


### PR DESCRIPTION
Just using latest, we should not be affected by any changes.