### PR TITLE
ci: Use 3.4.0 of chrome-webstore-upload-cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Submit to Google
         if: matrix.command == 'chrome'
-        run: npx chrome-webstore-upload-cli@2 upload --auto-publish --source extension/chrome.zip
+        run: npx chrome-webstore-upload-cli@3.4.0 --max-await-in-progress 300 --source extension/chrome.zip
         env:
           EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}


### PR DESCRIPTION
Updating to latest, pinning to an exact version, and using the new retry-functionality.